### PR TITLE
Units can observe fields to perform activation

### DIFF
--- a/src/pl/kaqu/pg/engine/error/PGError.java
+++ b/src/pl/kaqu/pg/engine/error/PGError.java
@@ -20,4 +20,7 @@ package pl.kaqu.pg.engine.error;
  */
 
 public class PGError extends Exception {
+    public PGError(String s) {
+        super(s);
+    }
 }

--- a/src/pl/kaqu/pg/engine/gamearea/PGUnitContainer.java
+++ b/src/pl/kaqu/pg/engine/gamearea/PGUnitContainer.java
@@ -25,16 +25,15 @@ import pl.kaqu.pg.engine.gamearea.behaviour.PGUnitContainerObserver;
 import pl.kaqu.pg.engine.unit.PGUnit;
 
 import java.util.HashSet;
+import java.util.Observable;
 import java.util.Set;
 
-public class PGUnitContainer {
+public class PGUnitContainer extends Observable {
 
     protected PGUnit containedUnit;
-    private Set<PGUnitContainerObserver> observers;
 
     public PGUnitContainer(@Nullable PGUnit containedUnit) {
         this.containedUnit = containedUnit;
-        this.observers = new HashSet<>();
     }
 
     @Nullable public PGUnit getContainedUnit() {
@@ -43,7 +42,7 @@ public class PGUnitContainer {
 
     public void setContainedUnit(@Nullable PGUnit containedUnit) {
         this.containedUnit = containedUnit;
-        this.notifyFieldObservers();
+        this.notifyObservers();
     }
 
     @Nullable public PGUnit pickContainedUnit() {
@@ -51,20 +50,4 @@ public class PGUnitContainer {
         this.containedUnit = null;
         return tmp;
     }
-
-    public void registerObserver(@NotNull PGUnitContainerObserver observer) {
-        this.observers.add(observer);
-    }
-
-    public void removeObserver(@NotNull PGUnitContainerObserver observer) {
-        this.observers.remove(observer);
-    }
-
-    // TODO: check if this should be on another thread
-    private void notifyFieldObservers() {
-        for(PGUnitContainerObserver observer : this.observers) {
-            observer.notify(this);
-        }
-    }
-
 }

--- a/src/pl/kaqu/pg/engine/gamearea/behaviour/PGUnitContainerObserver.java
+++ b/src/pl/kaqu/pg/engine/gamearea/behaviour/PGUnitContainerObserver.java
@@ -22,7 +22,7 @@ package pl.kaqu.pg.engine.gamearea.behaviour;
 import com.sun.istack.internal.Nullable;
 import pl.kaqu.pg.engine.gamearea.PGUnitContainer;
 
-public interface PGUnitContainerObserver {
+import java.util.Observer;
 
-    void notify(@Nullable PGUnitContainer container);
+public interface PGUnitContainerObserver extends Observer {
 }

--- a/src/pl/kaqu/pg/engine/unit/PGUnit.java
+++ b/src/pl/kaqu/pg/engine/unit/PGUnit.java
@@ -20,6 +20,7 @@ package pl.kaqu.pg.engine.unit;
  */
 
 import com.sun.istack.internal.NotNull;
+import pl.kaqu.pg.engine.gamearea.behaviour.PGUnitContainerObserver;
 import pl.kaqu.pg.engine.player.PGPlayer;
 import pl.kaqu.pg.engine.unit.action.PGUnitAction;
 import pl.kaqu.pg.engine.unit.activation.PGUnitActivationCheckerCallable;
@@ -29,8 +30,9 @@ import pl.kaqu.pg.engine.unit.effect.PGUnitState;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Observer;
 
-public abstract class PGUnit implements Serializable {
+public abstract class PGUnit implements Serializable, PGUnitContainerObserver {
 
     public final long unitID;
     protected PGPlayer owner;

--- a/src/pl/kaqu/pg/engine/unit/PGUnit.java
+++ b/src/pl/kaqu/pg/engine/unit/PGUnit.java
@@ -42,16 +42,8 @@ public abstract class PGUnit implements Serializable, PGUnitContainerObserver {
 
     protected PGUnit(long unitID, @NotNull PGPlayer owner, @NotNull PGUnitGroup group, @NotNull PGUnitState state){
         this.unitID = unitID;
-        if (owner != null){
-            this.owner = owner;
-        } else {
-            this.owner = PGPlayer.NO_PLAYER;
-        }
-        if (group != null){
-            this.group = group;
-        } else {
-            this.group = PGUnitGroup.NONE;
-        }
+        this.owner = owner != null ? owner : PGPlayer.NO_PLAYER;
+        this.group = group != null ? group : PGUnitGroup.NONE;
         this.state = state;
         this.currentEffects = new ArrayList<>();
     }
@@ -61,6 +53,9 @@ public abstract class PGUnit implements Serializable, PGUnitContainerObserver {
     }
     public void setState(PGUnitState state) {
         this.state = state;
+    }
+    @NotNull public PGUnitGroup getGroup() {
+        return this.group;
     }
     abstract public int getPriority();
     abstract @NotNull public String getName();

--- a/src/pl/kaqu/pg/engine/unit/types/PGUnitHigh.java
+++ b/src/pl/kaqu/pg/engine/unit/types/PGUnitHigh.java
@@ -33,25 +33,27 @@ import java.util.*;
  */
 
 public abstract class PGUnitHigh extends PGUnit implements PGActivatedUnit {
-    Map<String, PGUnitContainer> containers;
+    Map<Integer, PGUnitContainer> currentUnitContainers;
+    public static final int FRONT = 0;
+    public static final int BACK = 1;
 
-    protected PGUnitHigh(long unitID, PGPlayer owner, PGUnitGroup group, PGUnitState state, @NotNull PGUnitContainer front_of_unit) throws PGError {
+    protected PGUnitHigh(long unitID, PGPlayer owner, PGUnitGroup group, PGUnitState state, @NotNull PGUnitContainer frontOfUnit) throws PGError {
         super(unitID, owner, group, state);
-        this.containers = new HashMap<>();
+        this.currentUnitContainers = new HashMap<>();
 
-        if(front_of_unit instanceof PGField) {
-            PGField back_of_unit = ((PGField) front_of_unit).getRearNeighbor();
+        if(frontOfUnit instanceof PGField) {
+            PGField backOfUnit = ((PGField) frontOfUnit).getRearNeighbor();
 
-            if(back_of_unit == null) {
+            if(backOfUnit == null) {
                 throw new PGError("Incorrect location of unit");
             }
 
-            this.containers.put("front", front_of_unit);
-            this.containers.put("back", back_of_unit);
+            this.currentUnitContainers.put(FRONT, frontOfUnit);
+            this.currentUnitContainers.put(BACK, backOfUnit);
 
             List<PGField> toObserve = new ArrayList<>();
-            toObserve.add(back_of_unit.getRearNeighbor());
-            toObserve.add(back_of_unit.getSecondRearNeighbor());
+            toObserve.add(backOfUnit.getRearNeighbor());
+            toObserve.add(backOfUnit.getSecondRearNeighbor());
 
             if(!toObserve.contains(null)) {
                 for(PGField field : toObserve) {
@@ -64,30 +66,6 @@ public abstract class PGUnitHigh extends PGUnit implements PGActivatedUnit {
 
     @Override
     public void update(Observable obj, Object arg) {
-        if(this.containers.get("back") instanceof PGField) {
-            PGField field = (PGField) this.containers.get("back");
-            List<PGUnit> units = new ArrayList<>();
-
-            try {
-                units.add(field.getRearNeighbor().getContainedUnit());
-                units.add(field.getSecondRearNeighbor().getContainedUnit());
-            } catch(NullPointerException e) {
-                return;
-            }
-
-            if(units.contains(null)) {
-                return;
-            }
-
-            Set<PGUnitGroup> unique_groups = new HashSet<>();
-            unique_groups.add(this.group);
-            for(PGUnit unit : units) {
-                unique_groups.add(unit.getGroup());
-            }
-
-            if(unique_groups.size() == 1) {
-                this.state = PGUnitState.ACTIVATED; //TODO: Perform real activation here
-            }
-        }
+        //TODO: Register yourself for checking of activation
     }
 }

--- a/src/pl/kaqu/pg/engine/unit/types/PGUnitHigh.java
+++ b/src/pl/kaqu/pg/engine/unit/types/PGUnitHigh.java
@@ -1,12 +1,18 @@
 package pl.kaqu.pg.engine.unit.types;
 
+import com.sun.istack.internal.NotNull;
+import pl.kaqu.pg.engine.error.PGError;
 import pl.kaqu.pg.engine.gamearea.PGField;
+import pl.kaqu.pg.engine.gamearea.PGUnitContainer;
 import pl.kaqu.pg.engine.player.PGPlayer;
 import pl.kaqu.pg.engine.unit.PGUnit;
 import pl.kaqu.pg.engine.unit.PGUnitGroup;
 import pl.kaqu.pg.engine.unit.activation.PGActivatedUnit;
 import pl.kaqu.pg.engine.unit.activation.PGActivationType;
 import pl.kaqu.pg.engine.unit.effect.PGUnitState;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /*
     PuzzleGenerals
@@ -28,9 +34,33 @@ import pl.kaqu.pg.engine.unit.effect.PGUnitState;
  */
 
 public abstract class PGUnitHigh extends PGUnit implements PGActivatedUnit {
+    List<PGUnitContainer> containers;
 
-    protected PGUnitHigh(long unitID, PGPlayer owner, PGUnitGroup group, PGUnitState state) {
+    protected PGUnitHigh(long unitID, PGPlayer owner, PGUnitGroup group, PGUnitState state, @NotNull PGUnitContainer front_of_unit) throws PGError {
         super(unitID, owner, group, state);
+        this.containers = new ArrayList<>();
+
+        if(front_of_unit instanceof PGField) {
+            PGField back_of_unit = ((PGField) front_of_unit).getRearNeighbor();
+
+            if(back_of_unit == null) {
+                throw new PGError("Incorrect location of unit");
+            }
+
+            containers.add(front_of_unit);
+            containers.add(back_of_unit);
+
+            List<PGField> toObserve = new ArrayList<>();
+            toObserve.add(back_of_unit.getRearNeighbor());
+            toObserve.add(back_of_unit.getSecondRearNeighbor());
+
+            if(!toObserve.contains(null)) {
+                for(PGField field : toObserve) {
+                    field.addObserver(this);
+                }
+            }
+
+        }
     }
 
 }

--- a/src/pl/kaqu/pg/engine/unit/types/PGUnitLarge.java
+++ b/src/pl/kaqu/pg/engine/unit/types/PGUnitLarge.java
@@ -8,7 +8,6 @@ import pl.kaqu.pg.engine.player.PGPlayer;
 import pl.kaqu.pg.engine.unit.PGUnit;
 import pl.kaqu.pg.engine.unit.PGUnitGroup;
 import pl.kaqu.pg.engine.unit.activation.PGActivatedUnit;
-import pl.kaqu.pg.engine.unit.activation.PGActivationType;
 import pl.kaqu.pg.engine.unit.effect.PGUnitState;
 
 import java.util.*;
@@ -33,39 +32,43 @@ import java.util.*;
  */
 
 public abstract class PGUnitLarge extends PGUnit implements PGActivatedUnit {
-    Map<String, PGUnitContainer> containers;
+    Map<Integer, PGUnitContainer> currentUnitContainers;
+    public static final int LEFT_FRONT = 0;
+    public static final int LEFT_BACK = 1;
+    public static final int RIGHT_FRONT = 2;
+    public static final int RIGHT_BACK = 3;
 
-    protected PGUnitLarge(long unitID, PGPlayer owner, PGUnitGroup group, PGUnitState state, @NotNull PGUnitContainer left_front_of_unit) throws PGError {
+    protected PGUnitLarge(long unitID, PGPlayer owner, PGUnitGroup group, PGUnitState state, @NotNull PGUnitContainer leftFrontOfUnit) throws PGError {
         super(unitID, owner, group, state);
-        this.containers = new HashMap<>();
+        this.currentUnitContainers = new HashMap<>();
 
-        if(left_front_of_unit instanceof PGField) {
-            PGField left_back_of_unit;
-            PGField right_front_of_unit;
-            PGField right_back_of_unit;
+        if(leftFrontOfUnit instanceof PGField) {
+            PGField leftBackOfUnit;
+            PGField rightFrontOfUnit;
+            PGField rightBackOfUnit;
 
             try {
-                left_back_of_unit = ((PGField) left_front_of_unit).getRearNeighbor();
-                right_front_of_unit = ((PGField) left_front_of_unit).getRightNeighbor();
-                right_back_of_unit = right_front_of_unit.getRearNeighbor();
+                leftBackOfUnit = ((PGField) leftFrontOfUnit).getRearNeighbor();
+                rightFrontOfUnit = ((PGField) leftFrontOfUnit).getRightNeighbor();
+                rightBackOfUnit = rightFrontOfUnit.getRearNeighbor();
             } catch(NullPointerException e) {
                 throw new PGError("Incorrect location of unit");
             }
 
-            containers.put("left_front", left_front_of_unit);
-            containers.put("left_back", left_back_of_unit);
-            containers.put("right_front", right_front_of_unit);
-            containers.put("right_back", right_back_of_unit);
+            currentUnitContainers.put(LEFT_FRONT, leftFrontOfUnit);
+            currentUnitContainers.put(LEFT_BACK, leftBackOfUnit);
+            currentUnitContainers.put(RIGHT_FRONT, rightFrontOfUnit);
+            currentUnitContainers.put(RIGHT_BACK, rightBackOfUnit);
 
-            if(containers.containsValue(null)) {
+            if(currentUnitContainers.containsValue(null)) {
                 throw new PGError("Incorrect location of unit");
             }
 
             List<PGField> toObserve = new ArrayList<>();
-            toObserve.add(left_back_of_unit.getRearNeighbor());
-            toObserve.add(left_back_of_unit.getSecondRearNeighbor());
-            toObserve.add(right_back_of_unit.getRearNeighbor());
-            toObserve.add(right_back_of_unit.getSecondRearNeighbor());
+            toObserve.add(leftBackOfUnit.getRearNeighbor());
+            toObserve.add(leftBackOfUnit.getSecondRearNeighbor());
+            toObserve.add(rightBackOfUnit.getRearNeighbor());
+            toObserve.add(rightBackOfUnit.getSecondRearNeighbor());
 
 
             if(!toObserve.contains(null)) {
@@ -78,32 +81,6 @@ public abstract class PGUnitLarge extends PGUnit implements PGActivatedUnit {
 
     @Override
     public void update(Observable obj, Object arg) {
-        if(this.containers.get("left_back") instanceof PGField && this.containers.get("right_back") instanceof PGField) {
-            PGField left_field = (PGField) this.containers.get("left_back");
-            PGField right_field = (PGField) this.containers.get("right_back");
-            List<PGUnit> units = new ArrayList<>();
-            try {
-                units.add(left_field.getRearNeighbor().getContainedUnit());
-                units.add(left_field.getSecondRearNeighbor().getContainedUnit());
-                units.add(right_field.getRearNeighbor().getContainedUnit());
-                units.add(right_field.getSecondRearNeighbor().getContainedUnit());
-            } catch (NullPointerException e) {
-                return;
-            }
-
-            if(units.contains(null)) {
-                return;
-            }
-
-            Set<PGUnitGroup> unique_groups = new HashSet<>();
-            unique_groups.add(this.group);
-            for(PGUnit unit : units) {
-                unique_groups.add(unit.getGroup());
-            }
-
-            if(unique_groups.size() == 1) {
-                this.state = PGUnitState.ACTIVATED; //TODO: Perform real activation here
-            }
-        }
+        //TODO: Register yourself for checking of activation
     }
 }

--- a/src/pl/kaqu/pg/engine/unit/types/PGUnitSmall.java
+++ b/src/pl/kaqu/pg/engine/unit/types/PGUnitSmall.java
@@ -10,6 +10,9 @@ import pl.kaqu.pg.engine.unit.activation.PGActivatedUnit;
 import pl.kaqu.pg.engine.unit.activation.PGActivationType;
 import pl.kaqu.pg.engine.unit.effect.PGUnitState;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /*
     PuzzleGenerals
     Copyright (C) 2016 kaqu kaqukal@gmail.com
@@ -37,12 +40,14 @@ public abstract class PGUnitSmall extends PGUnit implements PGActivatedUnit {
         this.container = container;
 
         if(container instanceof PGField) {
-            PGField rear = ((PGField) container).getRearNeighbor();
-            PGField second_rear = ((PGField) container).getSecondRearNeighbor();
+            List<PGField> toObserve = new ArrayList<>();
+            toObserve.add(((PGField) container).getRearNeighbor());
+            toObserve.add(((PGField) container).getSecondRearNeighbor());
 
-            if(rear != null && second_rear != null) {
-                rear.addObserver(this);
-                second_rear.addObserver(this);
+            if(!toObserve.contains(null)) {
+                for(PGField field : toObserve) {
+                    field.addObserver(this);
+                }
             }
         }
     }

--- a/src/pl/kaqu/pg/engine/unit/types/PGUnitSmall.java
+++ b/src/pl/kaqu/pg/engine/unit/types/PGUnitSmall.java
@@ -1,6 +1,7 @@
 package pl.kaqu.pg.engine.unit.types;
 
 import com.sun.istack.internal.NotNull;
+import pl.kaqu.pg.engine.error.PGError;
 import pl.kaqu.pg.engine.gamearea.PGField;
 import pl.kaqu.pg.engine.gamearea.PGUnitContainer;
 import pl.kaqu.pg.engine.player.PGPlayer;
@@ -10,8 +11,7 @@ import pl.kaqu.pg.engine.unit.activation.PGActivatedUnit;
 import pl.kaqu.pg.engine.unit.activation.PGActivationType;
 import pl.kaqu.pg.engine.unit.effect.PGUnitState;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.*;
 
 /*
     PuzzleGenerals
@@ -52,4 +52,30 @@ public abstract class PGUnitSmall extends PGUnit implements PGActivatedUnit {
         }
     }
 
+    @Override
+    public void update(Observable obj, Object arg) {
+        if(this.container instanceof PGField) {
+            List<PGUnit> units = new ArrayList<>();
+            try {
+                units.add(((PGField) container).getRearNeighbor().getContainedUnit());
+                units.add(((PGField) container).getSecondRearNeighbor().getContainedUnit());
+            } catch (NullPointerException e) {
+                return;
+            }
+
+            if(units.contains(null)) {
+                return;
+            }
+
+            Set<PGUnitGroup> unique_groups = new HashSet<>();
+            unique_groups.add(this.group);
+            for(PGUnit unit : units) {
+                unique_groups.add(unit.getGroup());
+            }
+
+            if(unique_groups.size() == 1) {
+                this.state = PGUnitState.ACTIVATED; //TODO: Perform real activation here
+            }
+        }
+    }
 }

--- a/src/pl/kaqu/pg/engine/unit/types/PGUnitSmall.java
+++ b/src/pl/kaqu/pg/engine/unit/types/PGUnitSmall.java
@@ -1,14 +1,12 @@
 package pl.kaqu.pg.engine.unit.types;
 
 import com.sun.istack.internal.NotNull;
-import pl.kaqu.pg.engine.error.PGError;
 import pl.kaqu.pg.engine.gamearea.PGField;
 import pl.kaqu.pg.engine.gamearea.PGUnitContainer;
 import pl.kaqu.pg.engine.player.PGPlayer;
 import pl.kaqu.pg.engine.unit.PGUnit;
 import pl.kaqu.pg.engine.unit.PGUnitGroup;
 import pl.kaqu.pg.engine.unit.activation.PGActivatedUnit;
-import pl.kaqu.pg.engine.unit.activation.PGActivationType;
 import pl.kaqu.pg.engine.unit.effect.PGUnitState;
 
 import java.util.*;
@@ -33,16 +31,16 @@ import java.util.*;
  */
 
 public abstract class PGUnitSmall extends PGUnit implements PGActivatedUnit {
-    PGUnitContainer container;
+    PGUnitContainer currentUnitContainers;
 
-    protected PGUnitSmall(long unitID, PGPlayer owner, PGUnitGroup group, PGUnitState state, @NotNull PGUnitContainer container){
+    protected PGUnitSmall(long unitID, PGPlayer owner, PGUnitGroup group, PGUnitState state, @NotNull PGUnitContainer currentUnitContainers){
         super(unitID, owner, group, state);
-        this.container = container;
+        this.currentUnitContainers = currentUnitContainers;
 
-        if(container instanceof PGField) {
+        if(this.currentUnitContainers instanceof PGField) {
             List<PGField> toObserve = new ArrayList<>();
-            toObserve.add(((PGField) container).getRearNeighbor());
-            toObserve.add(((PGField) container).getSecondRearNeighbor());
+            toObserve.add(((PGField) this.currentUnitContainers).getRearNeighbor());
+            toObserve.add(((PGField) this.currentUnitContainers).getSecondRearNeighbor());
 
             if(!toObserve.contains(null)) {
                 for(PGField field : toObserve) {
@@ -54,28 +52,6 @@ public abstract class PGUnitSmall extends PGUnit implements PGActivatedUnit {
 
     @Override
     public void update(Observable obj, Object arg) {
-        if(this.container instanceof PGField) {
-            List<PGUnit> units = new ArrayList<>();
-            try {
-                units.add(((PGField) container).getRearNeighbor().getContainedUnit());
-                units.add(((PGField) container).getSecondRearNeighbor().getContainedUnit());
-            } catch (NullPointerException e) {
-                return;
-            }
-
-            if(units.contains(null)) {
-                return;
-            }
-
-            Set<PGUnitGroup> unique_groups = new HashSet<>();
-            unique_groups.add(this.group);
-            for(PGUnit unit : units) {
-                unique_groups.add(unit.getGroup());
-            }
-
-            if(unique_groups.size() == 1) {
-                this.state = PGUnitState.ACTIVATED; //TODO: Perform real activation here
-            }
-        }
+        //TODO: Register yourself for checking of activation
     }
 }

--- a/src/pl/kaqu/pg/engine/unit/types/PGUnitSmall.java
+++ b/src/pl/kaqu/pg/engine/unit/types/PGUnitSmall.java
@@ -1,6 +1,8 @@
 package pl.kaqu.pg.engine.unit.types;
 
+import com.sun.istack.internal.NotNull;
 import pl.kaqu.pg.engine.gamearea.PGField;
+import pl.kaqu.pg.engine.gamearea.PGUnitContainer;
 import pl.kaqu.pg.engine.player.PGPlayer;
 import pl.kaqu.pg.engine.unit.PGUnit;
 import pl.kaqu.pg.engine.unit.PGUnitGroup;
@@ -28,9 +30,21 @@ import pl.kaqu.pg.engine.unit.effect.PGUnitState;
  */
 
 public abstract class PGUnitSmall extends PGUnit implements PGActivatedUnit {
+    PGUnitContainer container;
 
-    protected PGUnitSmall(long unitID, PGPlayer owner, PGUnitGroup group, PGUnitState state){
+    protected PGUnitSmall(long unitID, PGPlayer owner, PGUnitGroup group, PGUnitState state, @NotNull PGUnitContainer container){
         super(unitID, owner, group, state);
+        this.container = container;
+
+        if(container instanceof PGField) {
+            PGField rear = ((PGField) container).getRearNeighbor();
+            PGField second_rear = ((PGField) container).getSecondRearNeighbor();
+
+            if(rear != null && second_rear != null) {
+                rear.addObserver(this);
+                second_rear.addObserver(this);
+            }
+        }
     }
 
 }


### PR DESCRIPTION
Every unit in its constructor registers as observer to every field important to activation. No further changes (like picking) implemented.